### PR TITLE
remove link for Python AI toolkit

### DIFF
--- a/docs/pyaitoolkit.md
+++ b/docs/pyaitoolkit.md
@@ -19,5 +19,4 @@ For more information, check out these helpful resources:
 - [Redpaper Solution Guide](https://ibm.biz/zPAIT_redbook)
 - [FAQ](https://ibm.biz/BdPnfS)
 - [Annoucement Letter](https://ibm.biz/BdPnXX)
-- [Journey to Open Data Analytics](https://ibm.biz/BdPnE6)
 - [IBM Open Enterprise SDK for Python](https://www.ibm.com/products/open-enterprise-python-zos)

--- a/site/pyaitoolkit/index.html
+++ b/site/pyaitoolkit/index.html
@@ -1416,7 +1416,6 @@
 <li><a href="https://ibm.biz/zPAIT_redbook">Redpaper Solution Guide</a></li>
 <li><a href="https://ibm.biz/BdPnfS">FAQ</a></li>
 <li><a href="https://ibm.biz/BdPnXX">Annoucement Letter</a></li>
-<li><a href="https://ibm.biz/BdPnE6">Journey to Open Data Analytics</a></li>
 <li><a href="https://www.ibm.com/products/open-enterprise-python-zos">IBM Open Enterprise SDK for Python</a></li>
 </ul>
 


### PR DESCRIPTION
Remove the link highlighted below.

<img width="720" height="458" alt="image (10)" src="https://github.com/user-attachments/assets/21fb7721-fa9e-4b68-b17c-0f9731547b4c" />


